### PR TITLE
Prevent highlighting labels on double click

### DIFF
--- a/src/interface/style.css
+++ b/src/interface/style.css
@@ -50,3 +50,7 @@ table.detail-table tr td:first-child {
 .bp3-navbar {
   box-shadow: 1px 1px 20px 0px rgba(0, 0, 0, 0.5);
 }
+
+label.bp3-checkbox, label.bp3-radio {
+  user-select: none;
+}


### PR DESCRIPTION
With `user-select: none` on checkbox and radio button labels.